### PR TITLE
Always mixin storefront

### DIFF
--- a/addon/instance-initializers/inject-storefront.js
+++ b/addon/instance-initializers/inject-storefront.js
@@ -4,5 +4,7 @@ export function initialize(appInstance) {
 }
 
 export default {
+  name: 'inject-storefront',
+  after: 'mixin-storefront',
   initialize
 };

--- a/addon/instance-initializers/mixin-storefront.js
+++ b/addon/instance-initializers/mixin-storefront.js
@@ -1,0 +1,12 @@
+import LoadableStore from 'ember-data-storefront/mixins/loadable-store';
+
+export function initialize(appInstance) {
+  let store = appInstance.lookup('service:store');
+  store.reopen(LoadableStore);
+  store.resetCache();
+}
+
+export default {
+  name: 'mixin-storefront',
+  initialize
+};

--- a/addon/instance-initializers/mixin-storefront.js
+++ b/addon/instance-initializers/mixin-storefront.js
@@ -8,5 +8,6 @@ export function initialize(appInstance) {
 
 export default {
   name: 'mixin-storefront',
+  after: 'ember-data',
   initialize
 };

--- a/addon/services/storefront.js
+++ b/addon/services/storefront.js
@@ -5,12 +5,6 @@ import { deprecate } from '@ember/application/deprecations';
 export default Service.extend({
   store: Ember.inject.service(),
 
-  init() {
-    this._super(...arguments);
-
-    this.resetCache(false);
-  },
-
   findAll() {
     deprecate(
       'The storefront service has been deprecated, please use store.loadAll instead. Will be removed in 1.0.',
@@ -61,14 +55,12 @@ export default Service.extend({
     return this.get('store').hasLoadedIncludesForRecord(...arguments);
   },
 
-  resetCache(deprecate=true) {
-    if (deprecate) {
-      deprecate(
-        'The storefront service has been deprecated, please use store.resetCache instead. Will be removed in 1.0.',
-        false,
-        { id: 'ember-data-storefront.storefront-reset-cache', until: '1.0.0' }
-      );
-    }
+  resetCache() {
+    deprecate(
+      'The storefront service has been deprecated, please use store.resetCache instead. Will be removed in 1.0.',
+      false,
+      { id: 'ember-data-storefront.storefront-reset-cache', until: '1.0.0' }
+    );
 
     return this.get('store').resetCache(...arguments);
   }

--- a/app/instance-initializers/mixin-storefront.js
+++ b/app/instance-initializers/mixin-storefront.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-data-storefront/instance-initializers/mixin-storefront';

--- a/tests/dummy/app/services/store.js
+++ b/tests/dummy/app/services/store.js
@@ -1,4 +1,0 @@
-import LoadableStore from 'ember-data-storefront/mixins/loadable-store';
-import DS from 'ember-data';
-
-export default DS.Store.extend(LoadableStore);

--- a/tests/integration/changing-data-render-test.js
+++ b/tests/integration/changing-data-render-test.js
@@ -3,6 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import MirageServer from 'dummy/tests/integration/helpers/mirage-server';
 import { Model } from 'ember-cli-mirage';
 import { run } from '@ember/runloop';
+import LoadableStore from 'ember-data-storefront/mixins/loadable-store';
 
 moduleForComponent('Integration | Changing data render test', {
   integration: true,
@@ -17,6 +18,8 @@ moduleForComponent('Integration | Changing data render test', {
       }
     });
     this.store = this.container.lookup('service:store')
+    this.store.reopen(LoadableStore);
+    this.store.resetCache();
   },
 
   afterEach() {

--- a/tests/integration/components/assert-must-preload-test.js
+++ b/tests/integration/components/assert-must-preload-test.js
@@ -4,6 +4,7 @@ import { startMirage } from 'dummy/initializers/ember-cli-mirage';
 import hbs from 'htmlbars-inline-precompile';
 import DS from 'ember-data';
 import LoadableModel from 'ember-data-storefront/mixins/loadable-model';
+import LoadableStore from 'ember-data-storefront/mixins/loadable-store';
 
 moduleForComponent('assert-must-preload', 'Integration | Component | assert must preload', {
 
@@ -12,6 +13,8 @@ moduleForComponent('assert-must-preload', 'Integration | Component | assert must
   beforeEach() {
     DS.Model.reopen(LoadableModel);
     this.store = this.container.lookup('service:store')
+    this.store.reopen(LoadableStore);
+    this.store.resetCache();
     this.server = startMirage();
   },
 

--- a/tests/integration/mixins/loadable-model-test.js
+++ b/tests/integration/mixins/loadable-model-test.js
@@ -4,6 +4,7 @@ import { startMirage } from 'dummy/initializers/ember-cli-mirage';
 import { run } from '@ember/runloop';
 import DS from 'ember-data';
 import LoadableModel from 'ember-data-storefront/mixins/loadable-model';
+import LoadableStore from 'ember-data-storefront/mixins/loadable-store';
 
 moduleFor('mixin:loadable-model', 'Integration | Mixins | LoadableModel', {
   integration: true,
@@ -11,7 +12,10 @@ moduleFor('mixin:loadable-model', 'Integration | Mixins | LoadableModel', {
   beforeEach() {
     DS.Model.reopen(LoadableModel);
     this.server = startMirage();
+    
     this.inject.service('store')
+    this.store.reopen(LoadableStore);
+    this.store.resetCache();
 
     let post = server.create('post', { id: 1 });
     let author = server.create('author');

--- a/tests/integration/mixins/loadable-store/has-loaded-includes-for-record-test.js
+++ b/tests/integration/mixins/loadable-store/has-loaded-includes-for-record-test.js
@@ -28,6 +28,7 @@ moduleFor('mixin:loadable-store', 'Integration | Mixins | LoadableStore | hasLoa
 
     this.inject.service('store')
     this.store.reopen(LoadableStore);
+    this.store.resetCache();
   },
 
   afterEach() {

--- a/tests/integration/mixins/loadable-store/load-all-and-load-record-test.js
+++ b/tests/integration/mixins/loadable-store/load-all-and-load-record-test.js
@@ -29,6 +29,7 @@ moduleFor('mixin:loadable-store', 'Integration | Mixins | LoadableStore | loadAl
 
     this.inject.service('store')
     this.store.reopen(LoadableStore);
+    this.store.resetCache();
   },
 
   afterEach() {

--- a/tests/integration/mixins/loadable-store/load-all-test.js
+++ b/tests/integration/mixins/loadable-store/load-all-test.js
@@ -28,6 +28,7 @@ moduleFor('mixin:loadable-store', 'Integration | Mixins | LoadableStore | loadAl
 
     this.inject.service('store')
     this.store.reopen(LoadableStore);
+    this.store.resetCache();
   },
 
   afterEach() {

--- a/tests/integration/mixins/loadable-store/load-record-test.js
+++ b/tests/integration/mixins/loadable-store/load-record-test.js
@@ -29,6 +29,7 @@ moduleFor('mixin:loadable-store', 'Integration | Mixins | LoadableStore | loadRe
 
     this.inject.service('store')
     this.store.reopen(LoadableStore);
+    this.store.resetCache();
   },
 
   afterEach() {


### PR DESCRIPTION
For https://github.com/embermap/ember-data-storefront/issues/16

I think that if you install this addon we should apply the mixin to the store by default. It feels like a step that would be taken after every install, so we might as well do it automatically.

Some of this will get simplified when we remove the storefront service. Right now we're keeping that around and letting two mixins figure out how to setup your app with storefront.

cc @samselikoff 

