### PR TITLE
use build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 ---
 language: node_js
-node_js:
-  - "6"
-
 sudo: false
 dist: trusty
+node_js:
+  - "6"
 
 addons:
   chrome: stable
@@ -14,43 +13,50 @@ cache:
   directories:
     - $HOME/.npm
     - $HOME/.cache # includes bowers cache
+
 env:
   global:
-    # See https://git.io/vdao3 for details.
     - JOBS=1
-  matrix:
-    # we recommend new addons test the current and previous LTS
-    # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.8
-    - EMBER_TRY_SCENARIO=ember-lts-2.12
-    - EMBER_TRY_SCENARIO=ember-release
-    - EMBER_TRY_SCENARIO=ember-beta
-    - EMBER_TRY_SCENARIO=ember-canary
-    - EMBER_TRY_SCENARIO=ember-default
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  # Locking to Yarn 1.0.2 to work around https://github.com/yarnpkg/yarn/issues/4612
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.2
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn install --no-lockfile
-
-script:
-  # Usually, it's ok to finish the test scenario without reverting
-  #  to the addon's original dependency state, skipping "cleanup".
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup
-
-deploy:
-  provider: script
-  script: node_modules/.bin/ember deploy production
-  on:
-    branch: master
+  - yarn install
 
 notifications:
   email: false
+
+stages:
+  - test
+  - additional tests
+  - versioned tests
+  - deploy
+
+jobs:
+  fail_fast: true
+
+  include:
+    - stage: test
+      env: NAME=test
+      script: yarn test
+
+    - stage: additional tests
+      env: NAME=floating dependencies
+      install: yarn install --no-lockfile --non-interactive
+      script: yarn test
+
+    - stage: versioned tests
+      env: EMBER_TRY_SCENARIO=ember-lts-2.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
+    - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-beta
+    - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-default
+
+    - stage: deploy
+      if: (branch = master OR tag IS present) AND type = push
+      env: NAME=deploy
+      script: node_modules/.bin/ember deploy production

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
   directories:
     - $HOME/.npm
     - $HOME/.cache # includes bowers cache
+    - node_modules
 
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:each",
+    "test": "ember test",
+    "test:all": "ember try:each",
     "test:node": "qunit node-tests/**/*-test.js"
   },
   "dependencies": {


### PR DESCRIPTION
This PR uses travis build stages, which allows us to:
1. Run tests against current lockfile
2. Run tests against no lockfile
3. Run tests against all supported ember versions (ember-try)

If all of these tests pass, then we'll deploy if this is a push to the master branch. This way we only get one deploy and no deploy on PRs.

