### PR TITLE
loadAll is now loadRecords

### DIFF
--- a/fastboot-tests/adapter-test.js
+++ b/fastboot-tests/adapter-test.js
@@ -34,7 +34,7 @@ Qmodule('Fastboot', function(hooks) {
     server.close();
   });
 
-  test('A fastboot rendered app should display loadAll data fetched by the server', async function(assert) {
+  test('A fastboot rendered app should display loadRecords data fetched by the server', async function(assert) {
     let page = await fastboot.visit('/fastboot-tests/load-all-posts', visitOptions);
     let html = await page.html();
     let dom = new JSDOM(html);
@@ -43,7 +43,7 @@ Qmodule('Fastboot', function(hooks) {
     assert.equal(post1.textContent.trim(), 'Hello from Ember CLI HTTP Mocks');
   });
 
-  test('A fastboot rendered app should put storefront loadAll queries in the shoebox', async function(assert) {
+  test('A fastboot rendered app should put storefront loadRecords queries in the shoebox', async function(assert) {
     let page = await fastboot.visit('/fastboot-tests/load-all-posts', visitOptions);
     let html = await page.html();
     let dom = new JSDOM(html);

--- a/tests/dummy/app/pods/docs/guides/data-fetching/demo-2/component.js
+++ b/tests/dummy/app/pods/docs/guides/data-fetching/demo-2/component.js
@@ -26,7 +26,7 @@ export default Component.extend({
         // BEGIN-SNIPPET demo2-posts-route.js
         // route
         model() {
-          return this.get('store').loadAll('post');
+          return this.get('store').loadRecords('post');
         }
         // END-SNIPPET
       },

--- a/tests/dummy/app/pods/docs/guides/data-fetching/template.md
+++ b/tests/dummy/app/pods/docs/guides/data-fetching/template.md
@@ -29,7 +29,7 @@ Storefront's modified version of `findAll` was designed to avoid re-rendering pr
 ```diff
   model() {
 -   return this.get('store').findAll('post');
-+   return this.get('store').loadAll('post');
++   return this.get('store').loadRecords('post');
   }
 
   model() {

--- a/tests/dummy/app/pods/docs/guides/data-fetching/template.md
+++ b/tests/dummy/app/pods/docs/guides/data-fetching/template.md
@@ -44,9 +44,9 @@ Now let's take a look at our app (be sure to click reset first):
 
 Notice that the behavior for the second scenario has changed. If we visit `/posts/1` first, and then click on `/posts`, we get a blocking promise. Storefront knows you haven't loaded all the `post` models yet, so instead of resolving instantly with the one post you happen to have in the store, it issues a network request for all posts and returns a blocking promise. In this way, you avoid the index route being in a state that you as the developer didn't intend.
 
-Storefront accomplishes this by tracking each query and its results individually. If you had previously been using `store.findAll` as a way of rendering all models in Ember Data's store, regardless of how they were loaded, then you should be aware that `loadRecords` is not a drop-in replacement for `findAll`.
+Storefront accomplishes this by tracking each query and its results individually. If you had previously been using `findAll` as a way of rendering all models in Ember Data's store, regardless of how they were loaded, then you should be aware that `loadRecords` is not a drop-in replacement for `findAll`.
 
-To correctly replace all calls to `findAll` with `loadRecords` you should also use `store.peekAll`:
+To correctly replace all calls to `findAll` with `loadRecords` you'll need to also use `store.peekAll`:
 
 
 ```diff
@@ -56,5 +56,7 @@ To correctly replace all calls to `findAll` with `loadRecords` you should also u
 +   return this.get('store').peekAll('posts');
   }
 ```
+
+Returning `peekAll` will ensure that the route is aware of any new posts created or loaded since its model hook ran. This matches the behavior of `findAll`, which is to load all posts and then return a live binding to all posts in Ember Data's store.
 
 Philosophically, Storefront's position is that routes (and other data-loading parts of your application) should be as declarative as possible. If you return `findAll('post')` from your route, you are declaring that this route needs a list of all posts in order to render. If your application has never made that network request, then it should block until it has made it for the first time. On subsequent visits, the page will render instantly using the cached value, as you can see by clicking around in the demo above.

--- a/tests/dummy/app/pods/docs/guides/data-fetching/template.md
+++ b/tests/dummy/app/pods/docs/guides/data-fetching/template.md
@@ -53,7 +53,7 @@ To correctly replace all calls to `findAll` with `loadRecords` you'll need to al
   async model() {
 -   return this.get('store').findAll('post');
 +   await this.get('store').loadRecords('post');
-+   return this.get('store').peekAll('posts');
++   return this.get('store').peekAll('post');
   }
 ```
 

--- a/tests/dummy/app/pods/docs/guides/working-with-relationships/template.md
+++ b/tests/dummy/app/pods/docs/guides/working-with-relationships/template.md
@@ -41,7 +41,7 @@ Similar to `load`, the first call to `reloadWith` will return a blocking promise
 **Why avoid async relationships?**
 
 <aside>
-  Read "[The Case against Async Relationships](https://embermap.com/notes/83-the-case-against-async-relationships)" to learn more about our thinking on this topic.
+  Read <a href="https://embermap.com/notes/83-the-case-against-async-relationships" class="docs-text-grey-darker">The Case against Async Relationships</a> to learn more about our thinking on this topic.
 </aside>
 
 We're of the opinion that many data-loading issues can be solved by avoiding async relationships.

--- a/tests/dummy/app/pods/fastboot-tests/load-all-posts/route.js
+++ b/tests/dummy/app/pods/fastboot-tests/load-all-posts/route.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   model: function() {
-    return this.store.loadAll('post', { filter: { popular: true }});
+    return this.store.loadRecords('post', { filter: { popular: true }});
   },
 });

--- a/tests/integration/changing-data-render-test.js
+++ b/tests/integration/changing-data-render-test.js
@@ -59,7 +59,7 @@ module('Integration | Changing data render test', function(hooks) {
     this.server.createList('post', 2);
 
     await run(() => {
-      return this.store.loadAll('post')
+      return this.store.loadRecords('post')
         .then(posts => {
           this.set('model', posts);
         });

--- a/tests/integration/mixins/loadable-store/load-all-test.js
+++ b/tests/integration/mixins/loadable-store/load-all-test.js
@@ -5,7 +5,7 @@ import MirageServer from 'dummy/tests/integration/helpers/mirage-server';
 import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
 import LoadableStore from 'ember-data-storefront/mixins/loadable-store';
 
-module('Integration | Mixins | LoadableStore | loadAll', function(hooks) {
+module('Integration | Mixins | LoadableStore | loadRecords', function(hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function() {
@@ -39,7 +39,7 @@ module('Integration | Mixins | LoadableStore | loadAll', function(hooks) {
   test('it can load a collection', async function(assert) {
     let post = this.server.create('post');
 
-    let posts = await this.store.loadAll('post');
+    let posts = await this.store.loadRecords('post');
 
     assert.equal(posts.get('length'), 1);
     assert.equal(posts.get('firstObject.id'), post.id);
@@ -50,13 +50,13 @@ module('Integration | Mixins | LoadableStore | loadAll', function(hooks) {
     let serverCalls = 0;
     this.server.pretender.handledRequest = () => serverCalls++;
 
-    let posts = await this.store.loadAll('post', serverPost.id);
+    let posts = await this.store.loadRecords('post', serverPost.id);
 
     assert.equal(serverCalls, 1);
     assert.equal(posts.get('length'), 2);
 
     this.server.create('post');
-    posts = await this.store.loadAll('post', serverPost.id);
+    posts = await this.store.loadRecords('post', serverPost.id);
 
     assert.equal(serverCalls, 1);
     assert.equal(posts.get('length'), 2);
@@ -75,8 +75,8 @@ module('Integration | Mixins | LoadableStore | loadAll', function(hooks) {
       assert.ok(!request.queryParams.reload);
     };
 
-    await this.store.loadAll('post', { reload: true });
-    let posts = await this.store.loadAll('post', { reload: true });
+    await this.store.loadRecords('post', { reload: true });
+    let posts = await this.store.loadRecords('post', { reload: true });
 
     assert.equal(serverCalls, 2);
     assert.equal(posts.get('length'), 3);
@@ -89,7 +89,7 @@ module('Integration | Mixins | LoadableStore | loadAll', function(hooks) {
       serverCalls.push(args);
     };
 
-    let posts = await this.store.loadAll('post', {
+    let posts = await this.store.loadRecords('post', {
       filter: {
         testing: 123
       }
@@ -110,7 +110,7 @@ module('Integration | Mixins | LoadableStore | loadAll', function(hooks) {
       serverCalls.push(arguments);
     };
 
-    let posts = await this.store.loadAll('post', {
+    let posts = await this.store.loadRecords('post', {
       include: 'comments'
     });
 

--- a/tests/integration/mixins/loadable-store/load-record-test.js
+++ b/tests/integration/mixins/loadable-store/load-record-test.js
@@ -189,7 +189,7 @@ module('Integration | Mixins | LoadableStore | loadRecord', function(hooks) {
     assert.equal(serverCalls, 2);
   });
 
-  test('loadRecord resolves immediately if its called with no options and the record is already in the store from loadAll, then reloads it in the background', async function(assert) {
+  test('loadRecord resolves immediately if its called with no options and the record is already in the store from loadRecords, then reloads it in the background', async function(assert) {
     let serverPost = this.server.create('post', { title: 'My post' });
     let serverCalls = 0;
     this.server.pretender.handledRequest = function() {
@@ -197,7 +197,7 @@ module('Integration | Mixins | LoadableStore | loadRecord', function(hooks) {
     };
 
     await run(() => {
-      return this.store.loadAll('post');
+      return this.store.loadRecords('post');
     });
 
     let post = await run(() => {
@@ -210,7 +210,7 @@ module('Integration | Mixins | LoadableStore | loadRecord', function(hooks) {
     await waitUntil(() => serverCalls === 2);
   });
 
-  test('loadRecord blocks if its called with an includes, even if the record has already been loaded from loadAll', async function(assert) {
+  test('loadRecord blocks if its called with an includes, even if the record has already been loaded from loadRecords', async function(assert) {
     let serverPost = this.server.create('post', { title: 'My post' });
     let serverCalls = 0;
     this.server.pretender.handledRequest = function() {
@@ -218,7 +218,7 @@ module('Integration | Mixins | LoadableStore | loadRecord', function(hooks) {
     };
 
     await run(() => {
-      return this.store.loadAll('post');
+      return this.store.loadRecords('post');
     });
 
     let post = await run(() => {


### PR DESCRIPTION
`store.loadAll` is now `store.loadRecords`. `loadAll` is deprecated, but will continue to work until we release version `1.0.0`.

The naming of `loadAll` was too close to `findAll`, by renaming the function `loadRecords` it is clear that this is not a 1-to-1 substitute for `findAll`.

`store.findAll` will load all records as well as return a live binding to all records in the store. This mean that as new models are created, or loaded from elsewhere, they will appear in the list returned by `findAll`.

Similarly, `store.loadRecords` will also load all records. However, it will not return a live binding to the store. This means that any records created, or loaded from elsewhere, will not appear in this list returned from `loadRecords`.

Storefront users who wish to match `findAll` behavior should use `loadRecords` to load data and `store.peekAll` to access data.

```diff
  async model() {
-   return this.get('store').findAll('post');
+   await this.get('store').loadRecords('post');
+   return this.get('store').peekAll('post');
  }
```

Since `peekAll` will return a live binding to the store this route retains that same behavior as `findAll`.