### PR TITLE
Correct error message to tell me to use #sideload, not #reloadWith

### DIFF
--- a/addon/mixins/loadable-model.js
+++ b/addon/mixins/loadable-model.js
@@ -149,7 +149,7 @@ export default Mixin.create({
   */
   load(name, options = { reload: false, backgroundReload: true }) {
     assert(
-      `The #load method only works with a single relationship, if you need to load multiple relationships in one request please use the #reloadWith method [ember-data-storefront]`,
+      `The #load method only works with a single relationship, if you need to load multiple relationships in one request please use the #sideload method [ember-data-storefront]`,
       !isArray(name) && !name.includes(',') && !name.includes('.')
     );
 


### PR DESCRIPTION
probably something that will get fixed once reloadWith goes away, but I got this error today having only ever known sideload and was rather confused about this "new" method I'd never heard of.