### PR TITLE
fastboot-adapter fails when different domains are used: remove domain and protocol from shoebox key

### DIFF
--- a/addon/mixins/fastboot-adapter.js
+++ b/addon/mixins/fastboot-adapter.js
@@ -44,7 +44,7 @@ export default Mixin.create({
 
     return function(response) {
       if (isFastboot) {
-        let key = shoeboxize(cacheKey([type, url, params]));
+        let key = shoeboxize(cacheKey([type, url.replace(/^.*\/\/[^\/]+/, ''), params]));
         cache[key] = JSON.stringify(response);
       }
 
@@ -60,7 +60,7 @@ export default Mixin.create({
     let box = shoebox && shoebox.retrieve('ember-data-storefront');
 
     if (!isFastboot && box && box.queries && Object.keys(box.queries).length > 0) {
-      let key = shoeboxize(cacheKey([type, url, params]));
+      let key = shoeboxize(cacheKey([type, url.replace(/^.*\/\/[^\/]+/, ''), params]));
       payload = box.queries[key];
       delete box.queries[key];
     }


### PR DESCRIPTION
When an ember is run in fastboot mode and the ember-data adapter contains a conditional to use an internal domain in fastboot mode (within the private network) and a public domain (used by the browser), ember-data-storefront fails to recognise data on the browser which is available in the shoebox. 

Reason for this behaviour is that the full url (containing both the protocol and the host) is used to store the data within the shoebox. The browser now tries to lookup that data using its public domain, whereas all data on the fastboot server has been stored using the private domain.

This PR removes both the protocol as well as the domain from the url that is used within the shoebox key.