### PR TITLE
More robust type detection in get-key.js

### DIFF
--- a/addon/-private/utils/get-key.js
+++ b/addon/-private/utils/get-key.js
@@ -4,9 +4,9 @@ let _serializeParams = function(params={}, prefix) {
     .map((key) => {
       const value  = params[key];
 
-      if (params.constructor === Array) {
+      if (Array.isArray(params)) {
         key = `${prefix}[]`;
-      } else if (params.constructor === Object) {
+      } else if (params === Object(params)) {
         key = (prefix ? `${prefix}[${key}]` : key);
       }
 


### PR DESCRIPTION
Recently on our Ember app we've been having issues using ember-data-storefront to retrieve some - but not all - items from the shoebox. We determined that the frontend and Fastboot were able to generate the appropriate keys for retrieval, but ember-data-storefront was sometimes trying to fetch with malformed keys. We tracked the bug down to the object constructor comparison in `get-key.js`, where sometimes our params constructor appeared like so instead of as the Object constructor:

```
[Function: Object] {
  ___dart_isolate_tags_: [Object: null prototype] { _ZxYxX_0_: 1 }
}
```

This appears to have come from ember-cli-sass using dart-sass, which [pollutes the Object constructor](https://github.com/dart-lang/sdk/issues/38967). We still haven't determined why this only affects some uses of `cacheKey()`.

Granted, this bug is not ember-data-storefront's fault, but with a small change to `get-key.js` the library can validate arrays and objects without comparing constructors. Would you be supportive of this change?
