### PR TITLE
add option to configure when shoebox data expires

### DIFF
--- a/fastboot/instance-initializers/ember-data-storefront.js
+++ b/fastboot/instance-initializers/ember-data-storefront.js
@@ -6,6 +6,9 @@ export function initialize(applicationInstance) {
   let storefront = applicationInstance.lookup('service:storefront');
 
   shoebox.put('ember-data-storefront', {
+    get created() {
+      return storefront.get('fastbootShoeboxCreated');
+    },
     get queries() {
       return storefront.get('fastbootDataRequests');
     }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ember-cli-eslint": "^5.1.0",
     "ember-cli-fastboot": "^2.0.4",
     "ember-cli-htmlbars": "^4.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^3.0.0",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-mirage": "1.1.6",
     "ember-cli-qunit": "^4.3.2",

--- a/tests/dummy/app/pods/docs/guides/fastboot/template.md
+++ b/tests/dummy/app/pods/docs/guides/fastboot/template.md
@@ -38,3 +38,16 @@ The `FastbootAdapter` works by storing the results of AJAX requests into fastboo
 The adapter will delete queries from the shoebox as soon as they are used. This ensures that if your application ever tries to re-make a network request in the future, it will not be served a cached version.
 
 Fastboot rendered pages need to be generated quickly, since they are rendered on the server in an HTTP request-resposne cycle. Because of this, they tend to not make many network requests. This means that a few seconds after the browser re-renders a fastboot page, the query cache should be empty since the client rendered application will have re-fetched all of the fastboot data.
+
+## Configure an expiration date
+
+In certain cases, like the browser restoring its session, a cached version of the index.html page may be served, which contains shoebox data from the initial, cached request. The adapter is not aware that this data is stale, and outdated information is displayed to the user. To prevent this you can configure a duration after which data will no longer be served from the shoebox.
+
+```
+// config/environment.js
+ENV = {
+  storefront: {
+    maxAge: 10 // shoebox expires 10 minutes after the fastboot server has rendered the page
+  }
+}
+```


### PR DESCRIPTION
In certain cases, like the browser restoring its session, a cached version of the index.html page may be served by the browser, which contains shoebox data from the initial, cached request. The adapter is not aware that this data is stale, and outdated information is displayed to the user (without ever making a request to the backend). To prevent that, this PR adds a param to configure after which duration data no longer is served from the shoebox.

```
// config/environment.js
ENV = {
  storefront: {
    maxAge: 10 // shoebox expires 10 minutes after the fastboot server has rendered the page
  }
}
```


If this value is not present in `config/environment.js`, current behaviour is maintained: the shoebox does never expire.

The current date when the adapter is initialised is stored in the shoebox and is compared when rendered in the browser. This should be fine, unless the fastboot server is optimised to not tear down the adapter across different requests.

I also removed the `ember-cli-htmlbars-inline-precompile` dependency, as it is no longer needed:

```DEPRECATION: ember-cli-htmlbars-inline-precompile is no longer needed with ember-cli-htmlbars versions 4.0.0 and higher, please remove it from `package.json```

I tried to add some tests, but could not find a way to mock the config with the current test setup. If someone can provide a hint how to make that work, I'll give it another try.