### PR TITLE
Octanify, begin mixin deprecation

### DIFF
--- a/addon/components/assert-must-preload.js
+++ b/addon/components/assert-must-preload.js
@@ -1,5 +1,7 @@
+import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
-import Component from '@ember/component';
+
+export default class AssertMustPreloadComponent extends Component {
 
 /**
   _This component relies on JSON:API, and assumes that your server supports JSON:API includes._
@@ -25,11 +27,10 @@ import Component from '@ember/component';
   @class AssertMustPreload
   @public
 */
-export default Component.extend({
-  tagName: '',
+  constructor() {
+    super(...arguments);
 
-  didReceiveAttrs() {
-    let [ model, ...includes ] = this.get('args');
+    let { model, includes } = this.args;
     let parentComponent = this.parentView;
     let parentName = parentComponent ? parentComponent._debugContainerKey : 'template';
     let includesString = includes.join(',');
@@ -43,12 +44,6 @@ export default Component.extend({
       `You tried to render a ${parentName} that accesses relationships off of a ${model.constructor.modelName}, but that model didn't have all of its required relationships preloaded ('${includesString}'). Please make sure to preload the association. [ember-data-storefront]`,
       model.hasLoaded(includesString)
     );
-
-    return this._super(...arguments);
   }
 
-}).reopenClass({
-
-  positionalParams: 'args'
-
-});
+}

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -1,0 +1,174 @@
+import StoreService from '@ember-data/store';
+import { deprecate } from '@ember/application/deprecations';
+import { resolve } from 'rsvp';
+import Coordinator from 'ember-data-storefront/-private/coordinator';
+
+/**
+  This mixin that adds new data-loading methods to Ember Data's store.
+
+  It is automatically mixed into your application's store when you install the addon.
+
+  @class LoadableStore
+  @public
+*/
+export default class LoadableStoreService extends StoreService {
+
+  constructor() {
+    super(...arguments);
+
+    this.resetCache();
+  }
+
+  /**
+    `loadRecords` can be used in place of `store.query` to fetch a collection of records for the given type and options.
+
+    ```diff
+      this.get('store')
+    -   .query('post', { filter: { popular: true } })
+    +   .loadRecords('post', { filter: { popular: true } })
+        .then(models => models);
+    ```
+
+    `loadRecords` caches based on the query you provide, so each of the following examples would return a blocking promise the first time they are called, and instantly resolve from the cache thereafter.
+
+    ```js
+    // filters
+    store.loadRecords('post', { filter: { popular: true }});
+
+    // pagination
+    store.loadRecords('post', { page: { limit: 10, offset: 0 }});
+
+    // includes
+    store.loadRecords('post', { include: 'comments' });
+
+    // force an already loaded set to reload (blocking promise)
+    store.loadRecords('post', { reload: true });
+    ```
+
+    In most cases, `loadRecords` should be a drop-in replacement for `query` that eliminates bugs and improves your app's caching.
+
+    @method loadRecords
+    @param {String} type type of model to load
+    @param {Object} options (optional) a hash of options
+    @return {Promise} a promise resolving with the record array
+    @public
+  */
+  loadRecords(type, options={}) {
+    let query = this.coordinator.recordArrayQueryFor(type, options);
+    let shouldBlock = options.reload || !query.value;
+    let shouldBackgroundReload = (options.backgroundReload !== undefined) ? options.backgroundReload : true;
+    let promise;
+    let fetcher;
+
+    if (shouldBlock) {
+      promise = query.run();
+      fetcher = promise;
+
+    } else {
+      promise = resolve(query.value);
+
+      fetcher = shouldBackgroundReload ? query.run() : resolve();
+    }
+
+    fetcher.then(() => query.trackIncludes());
+
+    return promise;
+  }
+
+  loadAll(...args) {
+    deprecate(
+      'loadAll has been renamed to loadRecords. Please change all instances of loadAll in your app to loadRecords. loadAll will be removed in 1.0.',
+      false,
+      { id: 'ember-data-storefront.loadAll', until: '1.0.0' }
+    );
+
+    return this.loadRecords(...args);
+  }
+
+  /**
+    `loadRecord` can be used in place of `store.findRecord` to fetch a single record for the given type, id and options.
+
+    ```diff
+      this.get('store')
+    -   .findRecord('post', 1, { include: 'comments' })
+    +   .loadRecord('post', 1, { include: 'comments' })
+        .then(post => post);
+    ```
+
+    `loadRecord` caches based on the query you provide, so each of the following examples would return a blocking promise the first time they are called, and synchronously resolve from the cache thereafter.
+
+    ```js
+    // simple fetch
+    this.get('store').loadRecord('post', 1);
+
+    // includes
+    this.get('store').loadRecord('post', 1, { include: 'comments' });
+    ```
+
+    This solves many common bugs where `findRecord` would return immediately, even if important `includes` had never been loaded.
+
+    Similar to `store.findRecord`, you can force a query to reload using `reload: true`:
+
+    ```
+    // force an already loaded set to reload (blocking promise)
+    store.loadRecord('post', 1, { reload: true });
+    ```
+
+    In most cases, `loadRecord` should be a drop-in replacement for `findRecord` that eliminates bugs and improves your app's caching.
+
+    @method loadRecord
+    @param {String} type type of model to load
+    @param {Number} id id of model to load
+    @param {Object} options (optional) a hash of options
+    @return {Promise} a promise resolving with the record array
+    @public
+  */
+  loadRecord(type, id, options={}) {
+    let query = this.coordinator.recordQueryFor(type, id, options);
+    let shouldBlock = options.reload || !query.value;
+    let shouldBackgroundReload = (options.backgroundReload !== undefined) ? options.backgroundReload : true;
+    let promise;
+
+    if (shouldBlock) {
+      promise = query.run();
+
+    } else {
+      promise = resolve(query.value);
+
+      if (shouldBackgroundReload) {
+        query.run();
+      }
+    }
+
+    return promise;
+  }
+
+  /**
+    _This method relies on JSON:API, and assumes that your server supports JSON:API includes._
+
+    Lets you check whether you've ever loaded related data for a model.
+
+    ```js
+    this.get('store').hasLoadedIncludesForRecord('post', '1', 'comments.author');
+    ```
+
+    @method hasLoadedIncludesForRecord
+    @param {String} type type of model to check
+    @param {Number} id id of model to check
+    @param {String} includesString a JSON:API includes string representing the relationships to check
+    @return {Boolean} whether the includesString has been loaded
+    @public
+  */
+  hasLoadedIncludesForRecord(type, id, includesString) {
+    return this.coordinator.recordHasIncludes(type, id, includesString);
+  }
+
+  /**
+    @method resetCache
+    @private
+  */
+  resetCache() {
+    this.coordinator = new Coordinator(this);
+  }
+
+}

--- a/app/components/assert-must-preload.js
+++ b/app/components/assert-must-preload.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-data-storefront/components/assert-must-preload/component';
+export { default } from 'ember-data-storefront/components/assert-must-preload';

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-storefront/services/store';

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   "repository": "https://github.com/embermap/ember-data-storefront",
   "license": "MIT",
   "author": "",
-  "directories": {
-    "doc": "doc",
-    "test": "tests"
-  },
   "contributors": [
     "Sam Selikoff <sam.selikoff@gmail.com> (https://embermap.com)",
     "Ryan Toronto <ryanto@gmail.com> (https://embermap.com)"
   ],
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
   "scripts": {
     "build": "ember build",
     "lint:hbs": "ember-template-lint .",
@@ -32,9 +32,11 @@
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
-    "@ember/optional-features": "^1.0.0",
+    "@ember/optional-features": "^1.3.0",
     "@fortawesome/ember-fontawesome": "^0.2.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
+    "@glimmer/component": "^1.0.0",
+    "@glimmer/tracking": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^5.0.0",
@@ -87,6 +89,9 @@
   },
   "engines": {
     "node": "10.* || >= 12.*"
+  },
+  "ember": {
+    "edition": "octane"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/integration/components/assert-must-preload-test.js
+++ b/tests/integration/components/assert-must-preload-test.js
@@ -71,7 +71,7 @@ module('Integration | Component | assert must preload', function(hooks) {
     }
 
     await render(hbs`
-      {{assert-must-preload post "comments"}}
+      <AssertMustPreload @model={{this.post}} @includes={{array "comments"}} />
     `);
   });
 
@@ -93,7 +93,7 @@ module('Integration | Component | assert must preload', function(hooks) {
     }
 
     await render(hbs`
-      {{assert-must-preload post "author,comments"}}
+      <AssertMustPreload @model={{this.post}} @includes={{array "author,comments"}} />
     `);
   });
 
@@ -115,7 +115,7 @@ module('Integration | Component | assert must preload', function(hooks) {
     }
 
     await render(hbs`
-      {{assert-must-preload post "comments.author"}}
+      <AssertMustPreload @model={{this.post}} @includes={{array "comments.author"}} />
     `);
   });
 
@@ -125,7 +125,7 @@ module('Integration | Component | assert must preload', function(hooks) {
     });
 
     await render(hbs`
-      {{assert-must-preload post "comments"}}
+      <AssertMustPreload @model={{this.post}} @includes={{array "comments"}} />
     `);
 
     // if anything renders, we're ok
@@ -141,7 +141,7 @@ module('Integration | Component | assert must preload', function(hooks) {
       this.post = posts.get('firstObject');
 
       await render(hbs`
-        {{assert-must-preload post "comments"}}
+        <AssertMustPreload @model={{this.post}} @includes={{array "comments"}} />
 
         <div data-test-id="title">
           {{post.title}}
@@ -171,7 +171,7 @@ module('Integration | Component | assert must preload', function(hooks) {
       }
 
       await render(hbs`
-        {{assert-must-preload post "author,comments.author"}}
+        <AssertMustPreload @model={{this.post}} @includes={{array "author,comments.author"}} />
       `);
     });
   });

--- a/tests/unit/services/store-test.js
+++ b/tests/unit/services/store-test.js
@@ -1,0 +1,69 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
+import MirageServer from 'dummy/tests/integration/helpers/mirage-server';
+import { run } from '@ember/runloop';
+
+module('Unit | Service | store', function(hooks) {
+  setupTest(hooks);
+
+  // has-loaded-includes-for-record-test
+
+  hooks.beforeEach(function() {
+    this.server = new MirageServer({
+      models: {
+        // eslint-disable-next-line ember/no-new-mixins
+        post: Model.extend({
+          comments: hasMany(),
+          tags: hasMany()
+        }),
+        // eslint-disable-next-line ember/no-new-mixins
+        comment: Model.extend({
+          post: belongsTo()
+        }),
+        // eslint-disable-next-line ember/no-new-mixins
+        tag: Model.extend({
+          posts: hasMany()
+        })
+      },
+      baseConfig() {
+        this.resource('posts');
+      }
+    });
+
+    let service = this.owner.lookup('service:store');
+    service.resetCache();
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  test('it returns true if the relationship has been loaded', async function(assert) {
+    let service = this.owner.lookup('service:store');
+
+    let serverPost = this.server.create('post');
+    this.server.createList('comment', 3, { post: serverPost });
+
+    await run(() => {
+      return service.loadRecord('post', serverPost.id, {
+        include: 'comments'
+      });
+    });
+
+    assert.ok(service.hasLoadedIncludesForRecord('post', serverPost.id, 'comments'));
+  });
+
+  test('it returns false if the relationship has not been loaded', async function(assert) {
+    let service = this.owner.lookup('service:store');
+
+    let serverPost = this.server.create('post');
+    this.server.createList('comment', 3, { post: serverPost });
+
+    await run(() => {
+      return service.loadRecord('post', serverPost.id);
+    });
+
+    assert.notOk(service.hasLoadedIncludesForRecord('post', serverPost.id, 'comments'));
+  });
+});


### PR DESCRIPTION
- Run 'npx @ember/octanify'
- Convert `<AssertMustPreload />` to Glimmer component (introduces component arg breaking change)
-  Run `ember g service store` to override default StoreService, so we can get rid of mixins