### PR TITLE
ember 4: fix package import @ember/application/deprecations

### DIFF
--- a/addon/mixins/loadable-model.js
+++ b/addon/mixins/loadable-model.js
@@ -1,5 +1,5 @@
 import Mixin from '@ember/object/mixin';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug'
 import { assert } from '@ember/debug';
 import { resolve } from 'rsvp';
 import { isArray } from '@ember/array';

--- a/addon/mixins/loadable-store.js
+++ b/addon/mixins/loadable-store.js
@@ -1,5 +1,5 @@
 import Mixin from '@ember/object/mixin';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug'
 import { resolve } from 'rsvp';
 import Coordinator from 'ember-data-storefront/-private/coordinator';
 

--- a/addon/mixins/loadable.js
+++ b/addon/mixins/loadable.js
@@ -1,5 +1,5 @@
 import Mixin from '@ember/object/mixin';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug'
 import { on } from '@ember/object/evented';
 import LoadableModel from './loadable-model';
 

--- a/addon/services/storefront.js
+++ b/addon/services/storefront.js
@@ -1,5 +1,5 @@
 import Service, { inject as service } from '@ember/service';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug'
 
 // do not delete this service! it's being used to communicte cached payloads
 // between the client and the browser


### PR DESCRIPTION
The addon does not work with ember 4 because the imported package `deprecate from @ember/application/deprecations` has been moved to `import { deprecate } from '@ember/debug'`

https://deprecations.emberjs.com/v3.x/